### PR TITLE
Updated video link for NaviFields

### DIFF
--- a/data/locomotionvault-17-09-2020.json
+++ b/data/locomotionvault-17-09-2020.json
@@ -2702,7 +2702,7 @@
             "largeVE": "medium", 
             "dof": "2", 
             "magical": "no", 
-            "Video": "https://www.youtube.com/watch?v=weo7cstIPSQ", 
+            "Video": "https://www.youtube.com/watch?v=xv3jPzV0asI", 
             "Disambiguation": "", 
             "beyond ground": "no"
         }, 


### PR DESCRIPTION
The previous video link was not working, so I updated the link to now point to the conference presentation video.

The related issue is: https://github.com/locomotionvault/locomotionvault.github.io/issues/1